### PR TITLE
Harden Docker build and improve runtime validation

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,11 @@
+.git
+__pycache__/
+*.pyc
+*.pyo
+*.wav
+voices/
+config/*.yaml
+.DS_Store
+.env
+.env.*
+speech.env

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,39 +1,44 @@
 FROM python:3.11-slim
 
-RUN --mount=type=cache,target=/root/.cache/pip pip install -U pip
-
+ARG DEBIAN_FRONTEND=noninteractive
 ARG TARGETPLATFORM
-RUN <<EOF
-apt-get update
-apt-get install --no-install-recommends -y curl ffmpeg
-if [ "$TARGETPLATFORM" != "linux/amd64" ]; then
-	apt-get install --no-install-recommends -y build-essential
-	curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
-fi
 
-# for deepspeed support - image +7.5GB, over the 10GB ghcr.io limit, and no noticable gain in speed or VRAM usage?
-#curl -O https://developer.download.nvidia.com/compute/cuda/repos/debian11/x86_64/cuda-keyring_1.1-1_all.deb
-#dpkg -i cuda-keyring_1.1-1_all.deb
-#rm cuda-keyring_1.1-1_all.deb
-#apt-get install --no-install-recommends -y libaio-dev build-essential cuda-toolkit
+RUN set -eux; \
+    apt-get update; \
+    apt-get install --no-install-recommends -y curl ffmpeg ca-certificates; \
+    rm -rf /var/lib/apt/lists/*
 
-apt-get clean
-rm -rf /var/lib/apt/lists/*
-EOF
-#ENV CUDA_HOME=/usr/local/cuda
+RUN set -eux; \
+    if [ "${TARGETPLATFORM}" != "linux/amd64" ]; then \
+        apt-get update; \
+        apt-get install --no-install-recommends -y build-essential; \
+        curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y; \
+        rm -rf /var/lib/apt/lists/*; \
+    fi
 ENV PATH="/root/.cargo/bin:${PATH}"
 
-WORKDIR /app
-RUN mkdir -p voices config
+ENV PYTHONDONTWRITEBYTECODE=1 PYTHONUNBUFFERED=1
 
-ARG USE_ROCM
+RUN useradd -m -u 10001 appuser
+
+WORKDIR /app
+RUN mkdir -p voices config && chown -R appuser:appuser /app
+
+ARG USE_ROCM=0
 ENV USE_ROCM=${USE_ROCM}
 
-COPY requirements*.txt /app/
-RUN if [ "${USE_ROCM}" = "1" ]; then mv /app/requirements-rocm.txt /app/requirements.txt; fi
-RUN --mount=type=cache,target=/root/.cache/pip pip install -r requirements.txt
+COPY requirements*.txt constraints*.txt /app/
+RUN set -eux; \
+    pip install -U pip; \
+    if [ "${USE_ROCM}" = "1" ] && [ -f requirements-rocm.txt ]; then mv requirements-rocm.txt requirements.txt; fi; \
+    if [ -f constraints.txt ]; then \
+        pip install --no-cache-dir -r requirements.txt -c constraints.txt; \
+    else \
+        pip install --no-cache-dir -r requirements.txt; \
+    fi
 
 COPY *.py *.sh *.default.yaml README.md LICENSE /app/
+RUN chown -R appuser:appuser /app
 
 ARG PRELOAD_MODEL
 ENV PRELOAD_MODEL=${PRELOAD_MODEL}
@@ -41,4 +46,6 @@ ENV TTS_HOME=voices
 ENV HF_HOME=voices
 ENV COQUI_TOS_AGREED=1
 
-CMD bash startup.sh
+USER appuser
+
+CMD ["bash", "startup.sh"]

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,19 @@
+.PHONY: build build-bk up down logs audit
+
+build:
+	docker build -t ghcr.io/matatonic/openedai-speech .
+
+build-bk:
+	DOCKER_BUILDKIT=1 docker build -t ghcr.io/matatonic/openedai-speech .
+
+up:
+	docker compose up -d
+
+down:
+	docker compose down
+
+logs:
+	docker compose logs -f
+
+audit:
+	pip-audit

--- a/README.md
+++ b/README.md
@@ -39,6 +39,53 @@ Details:
 
 If you find a better voice match for `tts-1` or `tts-1-hd`, please let me know so I can update the defaults.
 
+## Build & Run
+
+```bash
+# Classic builder
+docker build -t ghcr.io/matatonic/openedai-speech .
+docker run --rm -p 8000:8000 ghcr.io/matatonic/openedai-speech
+
+# With BuildKit (faster repeat builds)
+DOCKER_BUILDKIT=1 docker build -t ghcr.io/matatonic/openedai-speech .
+
+# Makefile helpers
+make build        # classic builder
+make build-bk     # BuildKit
+make up           # docker compose up -d
+```
+
+### Docker Compose example
+
+```yaml
+services:
+  server:
+    build:
+      context: .
+      dockerfile: Dockerfile
+    image: ghcr.io/matatonic/openedai-speech
+    ports: ["8000:8000"]
+    volumes:
+      - ./voices:/app/voices
+      - ./config:/app/config
+    environment:
+      - ORT_LOG_SEVERITY_LEVEL=3
+      - OMP_NUM_THREADS=1
+      - OPENBLAS_NUM_THREADS=1
+      - MKL_NUM_THREADS=1
+      - NUMEXPR_NUM_THREADS=1
+      - NVIDIA_VISIBLE_DEVICES=all
+    runtime: nvidia
+    restart: unless-stopped
+    healthcheck:
+      test: ["CMD", "curl", "-fsS", "http://localhost:8000/healthz"]
+      interval: 10s
+      timeout: 3s
+      retries: 10
+```
+
+Mount your customised `config/` and `voices/` directories as volumes. To keep secrets out of the compose file, store them in `.env` or use `env_file:` entries.
+
 ## Recent Changes
 
 Version 0.18.2, 2024-08-16
@@ -187,6 +234,27 @@ bash startup.sh
 
 > On first run, the voice models will be downloaded automatically. This might take a while depending on your network connection.
 
+### Install as a service (systemd)
+
+```bash
+sudo cp deploy/openedai-speech.service /etc/systemd/system/
+sudo systemctl daemon-reload
+sudo systemctl enable --now openedai-speech.service
+sudo systemctl status openedai-speech.service
+```
+
+Adjust `WorkingDirectory` in the unit file to match your checkout and store secrets in an `EnvironmentFile=` rather than inside the unit.
+
+### Maintenance & security
+
+* Python dependencies are capped via [`constraints.txt`](constraints.txt) to avoid sudden upgrades. Rebuild the image regularly for patched bases.
+* Run `make audit` (wraps `pip-audit`) before deployment to surface known vulnerabilities.
+* Keep credentials in `.env` files or systemd environment files rather than embedding them in Docker or systemd manifests.
+
+### Troubleshooting
+
+See [docs/TROUBLESHOOTING.md](docs/TROUBLESHOOTING.md) for fixes to common startup and runtime errors.
+
 ### Option B: Docker Image (*recommended*)
 
 #### Nvidia GPU (cuda)
@@ -194,6 +262,8 @@ bash startup.sh
 ```shell
 docker compose up
 ```
+
+> The compose example above already sets the health check, GPU runtime and thread-affinity environment variables. Run `make up` to launch it in detached mode.
 
 #### AMD GPU (ROCm support)
 

--- a/constraints.txt
+++ b/constraints.txt
@@ -1,0 +1,9 @@
+fastapi>=0.111,<0.115
+uvicorn>=0.29,<0.31
+loguru>=0.7,<0.8
+piper-tts>=1.2,<1.3
+coqui-tts>=0.23,<0.24
+langdetect>=1.0.9,<1.1
+pyyaml>=6.0.1,<6.1
+torch<3
+torchaudio<3

--- a/deploy/openedai-speech.service
+++ b/deploy/openedai-speech.service
@@ -1,0 +1,18 @@
+[Unit]
+Description=OpenedAI Speech TTS Service (Docker Compose)
+Requires=docker.service
+After=docker.service
+Wants=network-online.target
+
+[Service]
+Type=simple
+WorkingDirectory=/root/openedai/openedai-speech
+Environment=DOCKER_BUILDKIT=1
+ExecStart=/usr/bin/docker-compose -p openedai-speech -f docker-compose.yml up
+ExecStop=/usr/bin/docker-compose -p openedai-speech -f docker-compose.yml down
+Restart=always
+RestartSec=5
+TimeoutStartSec=60
+
+[Install]
+WantedBy=multi-user.target

--- a/docs/TROUBLESHOOTING.md
+++ b/docs/TROUBLESHOOTING.md
@@ -1,0 +1,77 @@
+# Troubleshooting
+
+This page collects the most common runtime warnings and errors along with quick fixes. Copy the exact commands to resolve issues inside the container (or adapt them to your environment).
+
+## `KeyError: 'default'` when calling `/v1/audio/speech`
+
+**Symptom**
+
+```
+ERROR - Error loading voice: default, KeyError: 'default'
+```
+
+**Fix**
+
+The request is using `voice="default"`, but the selected model namespace (for example `tts-1-hd`) does not define a `default:` mapping inside `config/voice_to_speaker.yaml`. Add a `default` entry that points to one of the configured voices, and make sure the YAML file is saved as UTF-8 without a BOM. After updating the file you can retry without restarting the container.
+
+```
+tts-1-hd:
+  default: alloy
+  alloy:
+    model: xtts
+    speaker: voices/alloy.wav
+```
+
+## `Unable to find voice: <name>` or “download voices” audio playback
+
+**Symptom**
+
+```
+ERROR - Voice 'nova' model missing: voices/en_US-libritts_r-medium.onnx
+```
+
+**Fix**
+
+The ONNX voice model file is not present under `/app/voices`. Download it inside the container:
+
+```bash
+docker exec -it <container> python3 -c "from pathlib import Path; import piper.download_voices as dl; dl.download_voice('<voice_code>', Path('/app/voices'))"
+```
+
+Replace `<voice_code>` with the identifier that matches the missing voice (for example `en_US-libritts_r-medium`).
+
+## `/sys/class/drm/card0` warnings during startup
+
+**Symptom**
+
+```
+[W:onnxruntime:, provider_bridge_ort.cc:1793 GetDefaultBackends] /sys/class/drm/card0 does not exist
+```
+
+**Fix**
+
+This warning is harmless and ONNX Runtime falls back to the available device. Set `ORT_LOG_SEVERITY_LEVEL=3` in the environment (already included in the compose example) to silence the message.
+
+## `pthread_setaffinity_np failed ... Invalid argument`
+
+**Symptom**
+
+```
+WARNING - pthread_setaffinity_np failed with error 22
+```
+
+**Fix**
+
+The container’s CPU affinity does not match the cpuset exposed by the host (common with LXC). Set the thread-related environment variables to `1` (see the docker-compose example) or adjust the host cpuset to include the allocated CPUs.
+
+## `dockerfile parse error ... APT-GET`
+
+**Symptom**
+
+```
+dockerfile parse error: Unknown instruction: APT-GET
+```
+
+**Fix**
+
+Older Docker builders do not support heredoc syntax. The refreshed Dockerfile avoids heredocs entirely; rebuild with the updated file or enable BuildKit: `DOCKER_BUILDKIT=1 docker build ...`.

--- a/speech.py
+++ b/speech.py
@@ -11,6 +11,9 @@ import threading
 import time
 import yaml
 import json
+from pathlib import Path
+
+from typing import Any, Dict, Optional, Set, Tuple
 
 from fastapi.responses import StreamingResponse
 from loguru import logger
@@ -33,6 +36,11 @@ async def lifespan(app):
 app = OpenAIStub(lifespan=lifespan)
 xtts = None
 args = None
+
+VOICE_CONFIG_PATH = Path("config/voice_to_speaker.yaml")
+_VOICE_CONFIG_NORMALIZED_WARNING_EMITTED = False
+_VOICE_CONFIG_SUMMARY_EMITTED = False
+_MISSING_MODEL_ERRORS_EMITTED: Set[Tuple[str, str, str]] = set()
 
 def unload_model():
     import torch, gc
@@ -110,24 +118,180 @@ class xtts_wrapper():
                 logger.debug(f"Generated {tokens} tokens in {time.time() - self.last_used:.2f}s @ {tokens / (time.time() - self.last_used):.2f} T/s")
                 self.last_used = time.time()
 
-def default_exists(filename: str):
-    if not os.path.exists(filename):
-        fpath, ext = os.path.splitext(filename)
-        basename = os.path.basename(fpath)
-        default = f"{basename}.default{ext}"
-        
-        logger.info(f"{filename} does not exist, setting defaults from {default}")
+def default_exists(filename: str) -> None:
+    file_path = Path(filename)
+    if not file_path.exists():
+        default = Path(f"{file_path.stem}.default{file_path.suffix}")
 
-        with open(default, 'r', encoding='utf8') as from_file:
-            with open(filename, 'w', encoding='utf8') as to_file:
+        logger.info(f"{file_path} does not exist, setting defaults from {default}")
+
+        with default.open('r', encoding='utf8') as from_file:
+            with file_path.open('w', encoding='utf8') as to_file:
                 to_file.write(from_file.read())
+
+
+def _clean_config_key(value: Any) -> Any:
+    if isinstance(value, str):
+        return value.replace("\ufeff", "").replace("\u200b", "").strip()
+    return value
+
+
+def _normalize_mapping(mapping: Dict[Any, Any]) -> Tuple[Dict[Any, Any], bool]:
+    normalized = False
+    cleaned: Dict[Any, Any] = {}
+
+    for key, value in mapping.items():
+        cleaned_key = _clean_config_key(key)
+        if cleaned_key != key:
+            normalized = True
+
+        if isinstance(value, dict):
+            cleaned_value, child_normalized = _normalize_mapping(value)
+            cleaned[cleaned_key] = cleaned_value
+            normalized = normalized or child_normalized
+        else:
+            cleaned[cleaned_key] = value
+
+    return cleaned, normalized
+
+
+def _resolve_path(path_str: str) -> Path:
+    path = Path(path_str).expanduser()
+    if not path.is_absolute():
+        path = Path.cwd() / path
+    return path
+
+
+def _missing_model_message(model_name: str, voice_name: str, resolved_path: Path, canonical_voice_code: str) -> str:
+    safe_code = canonical_voice_code.replace("'", "\\'")
+    fix_cmd = (
+        "docker exec -it <container> python3 -c "
+        "\"from pathlib import Path; import piper.download_voices as dl; "
+        f"dl.download_voice('{safe_code}', Path('/app/voices'))\""
+    )
+    return (
+        f"Voice '{voice_name}' for model '{model_name}' model missing: {resolved_path}\n"
+        f"Fix: {fix_cmd}"
+    )
+
+
+def load_voice_config(*, log_summary: bool = False) -> Dict[str, Dict[str, Any]]:
+    global _VOICE_CONFIG_NORMALIZED_WARNING_EMITTED, _VOICE_CONFIG_SUMMARY_EMITTED
+
+    default_exists(str(VOICE_CONFIG_PATH))
+
+    try:
+        with VOICE_CONFIG_PATH.open('r', encoding='utf-8-sig') as file:
+            raw_cfg = yaml.safe_load(file) or {}
+    except yaml.YAMLError as exc:
+        message = f"Failed to parse {VOICE_CONFIG_PATH}: {exc}"
+        logger.error(message)
+        raise BadRequestError(message, param='voice')
+    except FileNotFoundError:
+        message = f"Configuration file missing: {VOICE_CONFIG_PATH}"
+        logger.error(message)
+        raise BadRequestError(message, param='voice')
+
+    if not isinstance(raw_cfg, dict):
+        message = f"{VOICE_CONFIG_PATH} must define a mapping of models to voices."
+        logger.error(message)
+        raise BadRequestError(message, param='voice')
+
+    cleaned_cfg, normalized = _normalize_mapping(raw_cfg)
+    if normalized and not _VOICE_CONFIG_NORMALIZED_WARNING_EMITTED:
+        logger.warning("Config keys normalized due to hidden characters (BOM/ZWSP).")
+        _VOICE_CONFIG_NORMALIZED_WARNING_EMITTED = True
+
+    available_namespaces = {key for key in cleaned_cfg.keys() if isinstance(key, str)}
+    if not available_namespaces.intersection({'tts-1', 'tts-1-hd'}):
+        message = f"{VOICE_CONFIG_PATH} must contain at least one of: tts-1, tts-1-hd."
+        logger.error(message)
+        raise BadRequestError(message, param='model')
+
+    summary_lines = []
+
+    for model_name, voices in cleaned_cfg.items():
+        if not isinstance(model_name, str):
+            continue
+
+        if not isinstance(voices, dict):
+            message = f"Model '{model_name}' in {VOICE_CONFIG_PATH} must map to a dictionary of voices."
+            logger.error(message)
+            raise BadRequestError(message, param='voice')
+
+        if log_summary and not _VOICE_CONFIG_SUMMARY_EMITTED:
+            summary_lines.append(f"{model_name}:")
+
+        for voice_name, config in voices.items():
+            if voice_name == 'default':
+                if log_summary and not _VOICE_CONFIG_SUMMARY_EMITTED:
+                    if isinstance(config, str):
+                        summary_lines.append(f"  - default -> {config}")
+                    else:
+                        summary_lines.append("  - default -> inline configuration")
+                continue
+
+            if not isinstance(config, dict):
+                message = f"Voice '{voice_name}' in model '{model_name}' must be a mapping of settings."
+                logger.error(message)
+                raise BadRequestError(message, param='voice')
+
+            model_path = config.get('model')
+            if not model_path:
+                message = f"Voice '{voice_name}' in model '{model_name}' is missing the 'model' key."
+                logger.error(message)
+                raise BadRequestError(message, param='voice')
+
+            missing_model = None
+            resolved_model_path: Optional[Path] = None
+            if isinstance(model_path, str) and Path(model_path).suffix == '.onnx':
+                resolved_model_path = _resolve_path(model_path)
+                if not resolved_model_path.exists():
+                    canonical_voice_code = (
+                        config.get('download_code')
+                        or config.get('voice_code')
+                        or resolved_model_path.stem
+                    )
+                    missing_model = _missing_model_message(
+                        model_name,
+                        voice_name,
+                        resolved_model_path,
+                        canonical_voice_code,
+                    )
+                    key = (model_name, voice_name, str(resolved_model_path))
+                    if key not in _MISSING_MODEL_ERRORS_EMITTED:
+                        logger.error(missing_model)
+                        _MISSING_MODEL_ERRORS_EMITTED.add(key)
+
+            if log_summary and not _VOICE_CONFIG_SUMMARY_EMITTED:
+                status_bits = []
+                if isinstance(model_path, str) and Path(model_path).suffix == '.onnx':
+                    status_bits.append('model=' + ('ok' if missing_model is None else 'missing'))
+                else:
+                    status_bits.append('model=configured')
+
+                speaker_path = config.get('speaker')
+                if isinstance(speaker_path, str):
+                    resolved_speaker = _resolve_path(speaker_path)
+                    status_bits.append('speaker=' + ('ok' if resolved_speaker.exists() else 'missing'))
+
+                summary_lines.append(f"  - {voice_name}: {', '.join(status_bits)}")
+
+    if log_summary and not _VOICE_CONFIG_SUMMARY_EMITTED:
+        if summary_lines:
+            logger.info("Voice configuration summary:\n%s", "\n".join(summary_lines))
+        else:
+            logger.info("Voice configuration summary: no voices configured")
+        _VOICE_CONFIG_SUMMARY_EMITTED = True
+
+    return cleaned_cfg
 
 # Read pre process map on demand so it can be changed without restarting the server
 def preprocess(raw_input):
     #logger.debug(f"preprocess: before: {[raw_input]}")
     default_exists('config/pre_process_map.yaml')
-    with open('config/pre_process_map.yaml', 'r', encoding='utf8') as file:
-        pre_process_map = yaml.safe_load(file)
+    with open('config/pre_process_map.yaml', 'r', encoding='utf-8-sig') as file:
+        pre_process_map = yaml.safe_load(file) or []
         for a, b in pre_process_map:
             raw_input = re.sub(a, b, raw_input)
     
@@ -136,15 +300,83 @@ def preprocess(raw_input):
     return raw_input
 
 # Read voice map on demand so it can be changed without restarting the server
-def map_voice_to_speaker(voice: str, model: str):
-    default_exists('config/voice_to_speaker.yaml')
-    with open('config/voice_to_speaker.yaml', 'r', encoding='utf8') as file:
-        voice_map = yaml.safe_load(file)
-        try:
-            return voice_map[model][voice]
+def map_voice_to_speaker(voice: str, model: str) -> Tuple[Dict[str, Any], str]:
+    voice_map = load_voice_config()
 
-        except KeyError as e:
-            raise BadRequestError(f"Error loading voice: {voice}, KeyError: {e}", param='voice')
+    if model not in voice_map:
+        available = ', '.join(sorted(voice_map.keys())) or 'none'
+        message = f"Model '{model}' is not configured in {VOICE_CONFIG_PATH}. Available: {available}."
+        logger.error(message)
+        raise BadRequestError(message, param='model')
+
+    namespace = voice_map[model]
+    selected_voice = voice
+    config: Optional[Dict[str, Any]] = None
+
+    if voice == 'default':
+        default_entry = namespace.get('default')
+        if default_entry is None:
+            message = (
+                f"Model '{model}' is missing a 'default' entry while voice='default' was requested."
+            )
+            logger.error(message)
+            raise BadRequestError(message, param='voice')
+
+        if isinstance(default_entry, str):
+            selected_voice = default_entry
+            config = namespace.get(selected_voice)
+            if config is None:
+                message = (
+                    f"Model '{model}' default voice '{selected_voice}' is not defined in {VOICE_CONFIG_PATH}."
+                )
+                logger.error(message)
+                raise BadRequestError(message, param='voice')
+        elif isinstance(default_entry, dict):
+            config = default_entry
+        else:
+            message = (
+                f"Model '{model}' default entry must be a string or mapping, got {type(default_entry).__name__}."
+            )
+            logger.error(message)
+            raise BadRequestError(message, param='voice')
+
+    if config is None:
+        config = namespace.get(selected_voice)
+        if config is None:
+            available = ', '.join(sorted(v for v in namespace.keys() if v != 'default')) or 'none'
+            message = (
+                f"Voice '{voice}' is not configured for model '{model}'. Available voices: {available}."
+            )
+            logger.error(message)
+            raise BadRequestError(message, param='voice')
+
+    if not isinstance(config, dict):
+        message = f"Voice '{selected_voice}' for model '{model}' must be a mapping of settings."
+        logger.error(message)
+        raise BadRequestError(message, param='voice')
+
+    model_path = config.get('model')
+    if not model_path:
+        message = f"Voice '{selected_voice}' for model '{model}' is missing the 'model' key."
+        logger.error(message)
+        raise BadRequestError(message, param='voice')
+
+    if isinstance(model_path, str) and Path(model_path).suffix == '.onnx':
+        resolved_model = _resolve_path(model_path)
+        if not resolved_model.exists():
+            canonical_voice_code = (
+                config.get('download_code')
+                or config.get('voice_code')
+                or resolved_model.stem
+            )
+            message = _missing_model_message(model, selected_voice, resolved_model, canonical_voice_code)
+            key = (model, selected_voice, str(resolved_model))
+            if key not in _MISSING_MODEL_ERRORS_EMITTED:
+                logger.error(message)
+                _MISSING_MODEL_ERRORS_EMITTED.add(key)
+            raise BadRequestError(message, param='voice')
+
+    return dict(config), selected_voice
 
 class GenerateSpeechRequest(BaseModel):
     model: str = "tts-1" # or "tts-1-hd"
@@ -214,7 +446,8 @@ async def generate_speech(request: GenerateSpeechRequest):
 
     # Use piper for tts-1, and if xtts_device == none use for all models.
     if model == 'tts-1' or args.xtts_device == 'none':
-        voice_map = map_voice_to_speaker(voice, 'tts-1')
+        voice_map, resolved_voice = map_voice_to_speaker(voice, 'tts-1')
+        voice = resolved_voice
         try:
             piper_model = voice_map['model']
 
@@ -250,7 +483,8 @@ async def generate_speech(request: GenerateSpeechRequest):
         return StreamingResponse(content=ffmpeg_proc.stdout, media_type=media_type)
     # Use xtts for tts-1-hd
     elif model == 'tts-1-hd':
-        voice_map = map_voice_to_speaker(voice, 'tts-1-hd')
+        voice_map, resolved_voice = map_voice_to_speaker(voice, 'tts-1-hd')
+        voice = resolved_voice
         try:
             tts_model = voice_map.pop('model')
             speaker = voice_map.pop('speaker')
@@ -381,16 +615,36 @@ async def generate_speech(request: GenerateSpeechRequest):
             finally:
                 ffmpeg_proc.stdin.close()
 
+        generator_worker = None  # type: Optional[threading.Thread]
+        out_writer_worker = None  # type: Optional[threading.Thread]
+
+        def cleanup():
+            nonlocal generator_worker, out_writer_worker
+            try:
+                ffmpeg_proc.kill()
+            except Exception as exc:
+                logger.debug("Cleanup: ffmpeg kill failed: %r", exc)
+
+            for name, worker in (
+                ("generator_worker", generator_worker),
+                ("out_writer_worker", out_writer_worker),
+            ):
+                if worker is None:
+                    continue
+                try:
+                    if worker.is_alive():
+                        worker.join(timeout=0.5)
+                except Exception as exc:
+                    logger.debug("Cleanup: %s join failed: %r", name, exc)
+
+            generator_worker = None
+            out_writer_worker = None
+
         generator_worker = threading.Thread(target=generator, daemon=True)
         generator_worker.start()
 
         out_writer_worker = threading.Thread(target=out_writer, daemon=True)
         out_writer_worker.start()
-
-        def cleanup():
-            ffmpeg_proc.kill()
-            del generator_worker
-            del out_writer_worker
 
         return StreamingResponse(content=ffmpeg_proc.stdout, media_type=media_type, background=cleanup)
     else:
@@ -423,10 +677,15 @@ if __name__ == "__main__":
     args = parser.parse_args()
 
     default_exists('config/pre_process_map.yaml')
-    default_exists('config/voice_to_speaker.yaml')
 
     logger.remove()
     logger.add(sink=sys.stderr, level=args.log_level)
+
+    try:
+        load_voice_config(log_summary=True)
+    except BadRequestError as exc:
+        logger.error(getattr(exc, 'message', str(exc)))
+        sys.exit(1)
 
     if args.xtts_device != "none":
         import torch


### PR DESCRIPTION
## Summary
- refactor the Dockerfile to use classic RUN syntax, shrink the image, add dependency constraints, and run as an unprivileged user
- add build tooling and docs including a Makefile, .dockerignore, systemd unit, and troubleshooting guide, plus README updates for BuildKit and compose usage
- tighten speech server startup by normalizing/validating YAML, logging actionable errors, guarding cleanup threads, and improving default voice handling

## Testing
- python -m compileall speech.py

------
https://chatgpt.com/codex/tasks/task_e_68d7d8c2514083249ab61d5661abf4c7